### PR TITLE
Ensure explicit _clamp usage and normalize imports

### DIFF
--- a/backend/api/jobs.py
+++ b/backend/api/jobs.py
@@ -42,7 +42,7 @@ def register_job_routes(bp):
         # Create a new job folder & save artifacts via storage service
         try:
             # Lazy import to avoid hard dependency before services are scaffolded
-            from ..services.storage import new_job, save_upload, write_params, set_status  # type: ignore
+            from backend.services.storage import new_job, save_upload, write_params, set_status  # type: ignore
         except Exception:
             return api_error(503, "Storage service not ready (scaffold phase)")
 
@@ -56,7 +56,7 @@ def register_job_routes(bp):
         try:
             # Try to import real presets; fallback to built-ins if engine not present yet
             try:
-                from ..desolidify_engine.presets import PRESETS_DEFAULT  # type: ignore
+                from backend.desolidify_engine.presets import PRESETS_DEFAULT  # type: ignore
             except Exception:
                 PRESETS_DEFAULT = _fallback_presets()
             params = coerce_and_clamp_params(raw_params, preset_name=preset_name, presets=PRESETS_DEFAULT)
@@ -66,7 +66,7 @@ def register_job_routes(bp):
 
         # Queue the work
         try:
-            from ..services.queue import submit_perforate  # type: ignore
+            from backend.services.queue import submit_perforate  # type: ignore
         except Exception:
             # Mark as queued but not actually submitted (scaffold phase)
             set_status(job_id, state="queued", progress=0.0, message="Queue not available yet.")
@@ -92,7 +92,7 @@ def register_job_routes(bp):
     @bp.get("/jobs/<job_id>")
     def get_job(job_id: str):
         try:
-            from ..services.storage import get_status  # type: ignore
+            from backend.services.storage import get_status  # type: ignore
         except Exception:
             return jsonify({"job_id": job_id, "state": "unknown", "progress": 0.0, "message": "Storage not ready"}), 503
 
@@ -112,7 +112,7 @@ def register_job_routes(bp):
         if not out_path.exists():
             # Not ready yet
             try:
-                from ..services.storage import get_status  # type: ignore
+                from backend.services.storage import get_status  # type: ignore
                 st = get_status(job_id) or {}
             except Exception:
                 st = {}
@@ -146,7 +146,7 @@ def register_job_routes(bp):
         # Clamp params
         try:
             try:
-                from ..desolidify_engine.presets import PRESETS_DEFAULT  # type: ignore
+                from backend.desolidify_engine.presets import PRESETS_DEFAULT  # type: ignore
             except Exception:
                 PRESETS_DEFAULT = _fallback_presets()
             params = coerce_and_clamp_params(raw_params, preset_name=preset_name, presets=PRESETS_DEFAULT, force_fast=2)
@@ -156,7 +156,7 @@ def register_job_routes(bp):
         # Run preview (in-process, coarse)
         try:
             # Lazy import preview helper (to be provided in backend/desolidify_engine/preview.py)
-            from ..desolidify_engine.preview import run_preview_bytes  # type: ignore
+            from backend.desolidify_engine.preview import run_preview_bytes  # type: ignore
         except Exception:
             return api_error(501, "Preview engine not available yet (scaffold phase).")
 

--- a/backend/api/meta.py
+++ b/backend/api/meta.py
@@ -11,7 +11,7 @@ def register_meta_routes(bp):
     def get_presets():
         # Try loading from engine presets; fallback to inline subset
         try:
-            from ..desolidify_engine.presets import PRESETS_DEFAULT  # type: ignore
+            from backend.desolidify_engine.presets import PRESETS_DEFAULT  # type: ignore
             presets = PRESETS_DEFAULT
         except Exception:
             presets = _fallback_presets()

--- a/backend/app.py
+++ b/backend/app.py
@@ -157,7 +157,7 @@ def _register_cli(app: Flask) -> None:
     def purge_jobs(hours: int):
         """Delete old job folders."""
         try:
-            from .services.storage import purge_old_jobs  # type: ignore
+            from backend.services.storage import purge_old_jobs  # type: ignore
             deleted = purge_old_jobs(hours=hours)
             click.echo(f"Deleted {deleted} old job(s).")
         except Exception as e:

--- a/backend/desolidify_engine/__init__.py
+++ b/backend/desolidify_engine/__init__.py
@@ -1,14 +1,14 @@
 # backend/desolidify_engine/__init__.py
 from __future__ import annotations
 
-from .version import __version__
-from .settings import Settings, clamp_settings
-from .presets import PRESETS_DEFAULT
-from .engine import (
+from backend.desolidify_engine.version import __version__
+from backend.desolidify_engine.settings import Settings, clamp_settings
+from backend.desolidify_engine.presets import PRESETS_DEFAULT
+from backend.desolidify_engine.engine import (
     perforate_mesh_sdf,
     load_mesh_any,
 )
-from .preview import run_preview_bytes, run_preview_mesh
+from backend.desolidify_engine.preview import run_preview_bytes, run_preview_mesh
 
 __all__ = [
     "__version__",

--- a/backend/desolidify_engine/engine.py
+++ b/backend/desolidify_engine/engine.py
@@ -11,7 +11,7 @@ import numpy as np
 import trimesh
 from skimage.measure import marching_cubes
 
-from .settings import Settings
+from backend.desolidify_engine.settings import Settings
 
 # -----------------------------------------------------------------------------
 # Mesh I/O

--- a/backend/desolidify_engine/preview.py
+++ b/backend/desolidify_engine/preview.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, Dict, Optional
 
 import trimesh
 
-from .settings import Settings, from_params, clamp_settings
-from .engine import perforate_mesh_sdf
+from backend.desolidify_engine.settings import Settings, from_params, clamp_settings
+from backend.desolidify_engine.engine import perforate_mesh_sdf
 
 
 def run_preview_mesh(mesh: trimesh.Trimesh, params: Dict[str, Any],

--- a/backend/desolidify_engine/settings.py
+++ b/backend/desolidify_engine/settings.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, asdict
 from typing import Any, Dict, Optional
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -59,21 +62,21 @@ _PARAM_RANGES = {
 }
 
 
-def _clamp(v, lo=None, hi=None, *, min=None, max=None, **kwargs):
-    """Clamp v between lower/upper bounds.
+def _clamp(v, *, min=None, max=None, **extra):
+    """Clamp ``v`` between ``min`` and ``max``.
 
-    Supports both positional (lo, hi) and keyword (min=..., max=...) styles,
-    so callers can unpack dictionaries with either key format.
+    ``PARAM_SPECS`` and ``_PARAM_RANGES`` dictionaries both express bounds as
+    ``{"min": ..., "max": ...}``.  ``extra`` absorbs any additional keys so
+    callers can pass entire spec dictionaries without pruning first.
     """
-    if lo is None:
-        lo = min if min is not None else kwargs.get("min")
-    if hi is None:
-        hi = max if max is not None else kwargs.get("max")
+    logger.debug(
+        "Executing %s._clamp min=%r max=%r extra=%r", __name__, min, max, extra
+    )
 
-    if lo is not None and v < lo:
-        v = lo
-    if hi is not None and v > hi:
-        v = hi
+    if min is not None and v < min:
+        v = min
+    if max is not None and v > max:
+        v = max
     return v
 
 

--- a/backend/tasks/perforate.py
+++ b/backend/tasks/perforate.py
@@ -5,7 +5,7 @@ import io
 from pathlib import Path
 from typing import Any, Dict, Optional, Callable
 
-from ..services.storage import (
+from backend.services.storage import (
     job_dir,
     read_params,
     write_params,
@@ -13,9 +13,9 @@ from ..services.storage import (
     set_status,
     write_result,
 )
-from ..services.progress import set_progress as _set_progress
-from ..desolidify_engine.settings import from_params, clamp_settings
-from ..desolidify_engine.engine import perforate_mesh_sdf, load_mesh_any
+from backend.services.progress import set_progress as _set_progress
+from backend.desolidify_engine.settings import from_params, clamp_settings
+from backend.desolidify_engine.engine import perforate_mesh_sdf, load_mesh_any
 
 
 def _progress_cb(job_id: str) -> Callable[[float], None]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,15 +9,11 @@ from backend.api.schemas import coerce_and_clamp_params
 
 
 def test_clamp():
-    # lo/hi style
-    assert _clamp(5, lo=1, hi=10) == 5
-    assert _clamp(0, lo=1, hi=10) == 1
-    assert _clamp(15, lo=1, hi=10) == 10
-
-    # min/max style
     assert _clamp(5, min=1, max=10) == 5
     assert _clamp(0, min=1, max=10) == 1
     assert _clamp(15, min=1, max=10) == 10
+    # ignore unknown keys (mirrors PARAM_SPECS structure)
+    assert _clamp(5, min=1, max=10, tip="extra") == 5
 
 
 def test_coerce_and_clamp_params():


### PR DESCRIPTION
## Summary
- add module-level logger and debug trace for `_clamp`
- replace relative imports with explicit `backend.*` paths
- restore repository artifacts to avoid committing binary diffs
- drop legacy `lo`/`hi` parameters so `_clamp` accepts keyword-only `min`/`max`
- expand tests to ensure extra keys are ignored

## Testing
- `pytest -q`
- `python - <<'PY'
from backend.desolidify_engine.preview import run_preview_mesh
import trimesh
mesh = trimesh.creation.box(extents=(1,1,1))
params={"spacing":12,"radius":2.5,"voxel":0.3,"fast":1}
res = run_preview_mesh(mesh, params)
print("Preview vertices", len(res.vertices))
PY`
- `python - <<'PY'
from backend.api.schemas import coerce_and_clamp_params
from backend.desolidify_engine.settings import from_params
params_in = {"spacing":5,"radius":1,"voxel":0.3,"fast":0}
clamped = coerce_and_clamp_params(params_in)
print('API clamped', clamped)
settings = from_params(clamped)
print('Settings spacing', settings.spacing, 'radius', settings.radius)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c0c026d12883308fa261584fb5d117